### PR TITLE
Fix compilation error for 11.2+, upgrade gradle, upgrade JDK to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A loader for Ghidra supporting a variety of Nintendo Switch file formats.
 
 ## Building
 
-- Ensure you have ``JAVA_HOME`` set to the path of your JDK 17 installation.
+- Ensure you have ``JAVA_HOME`` set to the path of your JDK 21 installation.
 - Set ``GHIDRA_INSTALL_DIR`` to your Ghidra install directory. This can be done in one of the following ways:
   - **Windows**: Running ``set GHIDRA_INSTALL_DIR=<Absolute path to Ghidra without quotations>``
   - **macos/Linux**: Running ``export GHIDRA_INSTALL_DIR=<Absolute path to Ghidra>``

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ def ghidraUserDir = System.getProperty("user.home") + "/.ghidra/.${DISTRO_PREFIX
 
 dependencies {
     implementation 'commons-primitives:commons-primitives:1.0'
-    localDeps group: 'org.lz4', name: 'lz4-java', version: '1.5.1'
-    api configurations.localDeps
+    implementation group: 'org.lz4', name: 'lz4-java', version: '1.8.0'
+    localDeps group: 'org.lz4', name: 'lz4-java', version: '1.8.0'
 
     runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/patch', include: "**/*.jar")
     runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Configurations', include: "**/*.jar")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fix compilation error for 11.2+, upgrade gradle, upgrade JDK to 21.

Thanks to @borntohonk  for the help.